### PR TITLE
Add option to forward laz header info

### DIFF
--- a/bu/CopcSupport.cpp
+++ b/bu/CopcSupport.cpp
@@ -41,15 +41,16 @@ CopcSupport::CopcSupport(const BaseInfo& b) : m_b(b),
 
     m_f.open(toNative(b.opts.outputName), std::ios::out | std::ios::binary);
 
-    //ABELL
     m_header.global_encoding = m_b.globalEncoding;
     m_header.global_encoding |= (1 << 4); // Set for WKT
-    //ABELL
     m_header.file_source_id = m_b.fileSourceId;
     m_header.creation.day = m_b.creationDoy;
     m_header.creation.year = m_b.creationYear;
+//    m_b.systemId.copy(m_header.system_identifier, 32);
+//    m_b.generatingSoftware.copy(m_header.generating_software, 32);
     std::strncpy(m_header.system_identifier, m_b.systemId.c_str(), 32);
     std::strncpy(m_header.generating_software, m_b.generatingSoftware.c_str(), 32);
+
 
     m_header.header_size = lazperf::header14::Size;
     m_header.point_format_id = m_b.pointFormatId;

--- a/bu/CopcSupport.cpp
+++ b/bu/CopcSupport.cpp
@@ -42,11 +42,15 @@ CopcSupport::CopcSupport(const BaseInfo& b) : m_b(b),
     m_f.open(toNative(b.opts.outputName), std::ios::out | std::ios::binary);
 
     //ABELL
-    m_header.file_source_id = 0;
-    m_header.global_encoding = (1 << 4); // Set for WKT
+    m_header.global_encoding = m_b.globalEncoding;
+    m_header.global_encoding |= (1 << 4); // Set for WKT
     //ABELL
-    m_header.creation.day = 1;
-    m_header.creation.year = 1;
+    m_header.file_source_id = m_b.fileSourceId;
+    m_header.creation.day = m_b.creationDoy;
+    m_header.creation.year = m_b.creationYear;
+    std::strncpy(m_header.system_identifier, m_b.systemId.c_str(), 32);
+    std::strncpy(m_header.generating_software, m_b.generatingSoftware.c_str(), 32);
+
     m_header.header_size = lazperf::header14::Size;
     m_header.point_format_id = m_b.pointFormatId;
     m_header.point_format_id |= (1 << 7);    // Bit for laszip

--- a/bu/CopcSupport.cpp
+++ b/bu/CopcSupport.cpp
@@ -46,11 +46,8 @@ CopcSupport::CopcSupport(const BaseInfo& b) : m_b(b),
     m_header.file_source_id = m_b.fileSourceId;
     m_header.creation.day = m_b.creationDoy;
     m_header.creation.year = m_b.creationYear;
-//    m_b.systemId.copy(m_header.system_identifier, 32);
-//    m_b.generatingSoftware.copy(m_header.generating_software, 32);
-    std::strncpy(m_header.system_identifier, m_b.systemId.c_str(), 32);
-    std::strncpy(m_header.generating_software, m_b.generatingSoftware.c_str(), 32);
-
+    m_b.systemId.copy(m_header.system_identifier, 32);
+    m_b.generatingSoftware.copy(m_header.generating_software, 32);
 
     m_header.header_size = lazperf::header14::Size;
     m_header.point_format_id = m_b.pointFormatId;

--- a/epf/Epf.cpp
+++ b/epf/Epf.cpp
@@ -336,8 +336,8 @@ void Epf::fillMetadata(const pdal::PointLayoutPtr layout)
         return std::round(minval + offset);  // Add the base (min) value and round to an integer.
     };
 
-    // Preserve offsets if we have them and --forward_all is used
-    if (!m_b.forwardAll() ||
+    // Preserve offsets if we have them and --single_file with single input is used
+    if (!m_b.preserveHeaderFields() ||
             std::isnan(m_b.offset[0]) ||
             std::isnan(m_b.offset[1]) ||
             std::isnan(m_b.offset[2]))
@@ -427,7 +427,7 @@ PointCount Epf::createFileInfo(const StringList& input, StringList dimNames,
         if (m.valid())
             zOffsets.push_back(m.value<double>());
 
-        if (m_b.forwardAll())
+        if (m_b.preserveHeaderFields())
         {
             m = root.findChild("global_encoding");
             if (m.valid())

--- a/epf/Epf.cpp
+++ b/epf/Epf.cpp
@@ -336,9 +336,16 @@ void Epf::fillMetadata(const pdal::PointLayoutPtr layout)
         return std::round(minval + offset);  // Add the base (min) value and round to an integer.
     };
 
-    m_b.offset[0] = calcOffset(m_b.trueBounds.minx, m_b.trueBounds.maxx, m_b.scale[0]);
-    m_b.offset[1] = calcOffset(m_b.trueBounds.miny, m_b.trueBounds.maxy, m_b.scale[1]);
-    m_b.offset[2] = calcOffset(m_b.trueBounds.minz, m_b.trueBounds.maxz, m_b.scale[2]);
+    // Preserve offsets if we have them and --forward_all is used
+    if (!m_b.forwardAll() ||
+            std::isnan(m_b.offset[0]) ||
+            std::isnan(m_b.offset[1]) ||
+            std::isnan(m_b.offset[2]))
+    {
+        m_b.offset[0] = calcOffset(m_b.trueBounds.minx, m_b.trueBounds.maxx, m_b.scale[0]);
+        m_b.offset[1] = calcOffset(m_b.trueBounds.miny, m_b.trueBounds.maxy, m_b.scale[1]);
+        m_b.offset[2] = calcOffset(m_b.trueBounds.minz, m_b.trueBounds.maxz, m_b.scale[2]);
+    }
 }
 
 PointCount Epf::createFileInfo(const StringList& input, StringList dimNames,
@@ -419,6 +426,39 @@ PointCount Epf::createFileInfo(const StringList& input, StringList dimNames,
         m = root.findChild("offset_z");
         if (m.valid())
             zOffsets.push_back(m.value<double>());
+
+        if (m_b.forwardAll())
+        {
+            m = root.findChild("global_encoding");
+            if (m.valid())
+                m_b.globalEncoding = m.value<int>();
+            m = root.findChild("creation_doy");
+            if (m.valid())
+                m_b.creationDoy = m.value<int>();
+            m = root.findChild("creation_year");
+            if (m.valid())
+                m_b.creationYear = m.value<int>();
+            m = root.findChild("filesource_id");
+            if (m.valid())
+                m_b.fileSourceId = m.value<int>();
+            m = root.findChild("software_id");
+            if (m.valid())
+                m_b.generatingSoftware = m.value<std::string>();
+            m = root.findChild("system_id");
+            if (m.valid())
+                m_b.systemId = m.value<std::string>();
+        }
+        else
+        {
+            std::time_t now;
+            std::time(&now);
+            std::tm* ptm = std::gmtime(&now);
+            if (ptm)
+            {
+                m_b.creationDoy = ptm->tm_yday + 1;
+                m_b.creationYear = ptm->tm_year + 1900;
+            }
+        }
 
         FileInfo fi;
         fi.bounds = qi.m_bounds;

--- a/untwine/Common.hpp
+++ b/untwine/Common.hpp
@@ -48,7 +48,6 @@ struct Options
     bool stats;
     std::string a_srs;
     bool metadata;
-    bool forwardAll;
 };
 
 struct BaseInfo
@@ -57,7 +56,7 @@ public:
     BaseInfo()
     {};
 
-    bool forwardAll() const {return opts.forwardAll && opts.inputFiles.size() == 1;}
+    bool preserveHeaderFields() const {return opts.singleFile && opts.inputFiles.size() == 1;}
 
     Options opts;
     pdal::BOX3D bounds;

--- a/untwine/Common.hpp
+++ b/untwine/Common.hpp
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <array>
+#include <limits>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -47,6 +48,7 @@ struct Options
     bool stats;
     std::string a_srs;
     bool metadata;
+    bool forwardAll;
 };
 
 struct BaseInfo
@@ -54,6 +56,8 @@ struct BaseInfo
 public:
     BaseInfo()
     {};
+
+    bool forwardAll() const {return opts.forwardAll && opts.inputFiles.size() == 1;}
 
     Options opts;
     pdal::BOX3D bounds;
@@ -63,10 +67,18 @@ public:
     DimInfoList dimInfo;
     pdal::SpatialReference srs;
     int pointFormatId;
+    uint16_t globalEncoding {0};
+    uint16_t creationYear {1};
+    uint16_t creationDoy {1};
+    uint16_t fileSourceId {0};
+    std::string systemId;
+    std::string generatingSoftware { "Untwine" };
 
     using d3 = std::array<double, 3>;
     d3 scale { -1.0, -1.0, -1.0 };
-    d3 offset {};
+    d3 offset { std::numeric_limits<double>::quiet_NaN(),
+                std::numeric_limits<double>::quiet_NaN(),
+                std::numeric_limits<double>::quiet_NaN()};
 };
 
 // We make a special dimension to store the bits (class flags, scanner channel, scan dir, eofl).

--- a/untwine/Untwine.cpp
+++ b/untwine/Untwine.cpp
@@ -49,8 +49,6 @@ void addArgs(pdal::ProgramArgs& programArgs, Options& options, pdal::Arg * &temp
         options.a_srs, "");
     programArgs.add("metadata", "Write PDAL metadata to VLR output",
         options.metadata, false);
-    programArgs.add("forward_all", "Preserve header fields of source LAS/LAZ file. Only "
-        "applicable for single input and output files.", options.forwardAll, false);
 }
 
 bool handleOptions(pdal::StringList& arglist, Options& options)

--- a/untwine/Untwine.cpp
+++ b/untwine/Untwine.cpp
@@ -49,6 +49,8 @@ void addArgs(pdal::ProgramArgs& programArgs, Options& options, pdal::Arg * &temp
         options.a_srs, "");
     programArgs.add("metadata", "Write PDAL metadata to VLR output",
         options.metadata, false);
+    programArgs.add("forward_all", "Preserve header fields of source LAS/LAZ file. Only "
+        "applicable for single input and output files.", options.forwardAll, false);
 }
 
 bool handleOptions(pdal::StringList& arglist, Options& options)


### PR DESCRIPTION
This PR adds a `--forward_all` option. When this option is used in single file mode, and a single input las/laz file is used then the following header info are preserved:
- file source id
- global encoding (except the wkt bit)
- creation day
- creation year
- system identifier
- generating software
- offsets (scale was already preserved)

This will ultimately be used in QGIS by default so that Untwine is a transparent stage for the end user.

Also, when the `--forward_all` option is not used, the creation day/year is now correctly populated and the generating software is populated with `Untwine`

Fixes #139