### PR TITLE
Fix build with PDAL < 2.5

### DIFF
--- a/untwine/Untwine.cpp
+++ b/untwine/Untwine.cpp
@@ -14,6 +14,8 @@
 #include <pdal/util/FileUtils.hpp>
 #include <pdal/util/ProgramArgs.hpp>
 
+#include <regex>
+
 #include "Common.hpp"
 #include "Config.hpp"
 #include "ProgressWriter.hpp"


### PR DESCRIPTION
Build with PDAL < 2.5 was failing like this:
```
/home/martin/qgis/git-master/external/untwine/untwine/Untwine.cpp: In function ‘void untwine::cleanup(const string&, bool)’:
/home/martin/qgis/git-master/external/untwine/untwine/Untwine.cpp:112:10: error: ‘regex’ is not a member of ‘std’
  112 |     std::regex re("[0-9]+-[0-9]+-[0-9]+-[0-9]+.bin");
      |          ^~~~~
/home/martin/qgis/git-master/external/untwine/untwine/Untwine.cpp:113:10: error: ‘smatch’ is not a member of ‘std’; did you mean ‘search’?
  113 |     std::smatch sm;
      |          ^~~~~~
      |          search
/home/martin/qgis/git-master/external/untwine/untwine/Untwine.cpp:117:18: error: ‘regex_match’ is not a member of ‘std’
  117 |         if (std::regex_match(f, sm, re))
      |                  ^~~~~~~~~~~
/home/martin/qgis/git-master/external/untwine/untwine/Untwine.cpp:117:33: error: ‘sm’ was not declared in this scope; did you mean ‘tm’?
  117 |         if (std::regex_match(f, sm, re))
      |                                 ^~
      |                                 tm
/home/martin/qgis/git-master/external/untwine/untwine/Untwine.cpp:117:37: error: ‘re’ was not declared in this scope
  117 |         if (std::regex_match(f, sm, re))
      |                                     ^~
```


It looks like since https://github.com/PDAL/PDAL/commit/8986cd8cda398fd798a75294ef0f0480ea8aec52 (first included in 2.5) the `pdal_types.hpp` file contains `#include <regex>` that is now needed by `Untwine.cpp`. Let's include it in `Untwine.cpp` to make sure it works with earlier PDAL releases as well.