### PR TITLE
Return the exit code to QgisUntwine in case of no error message but no clean exit

### DIFF
--- a/api/QgisUntwine.cpp
+++ b/api/QgisUntwine.cpp
@@ -57,6 +57,9 @@ std::string QgisUntwine::errorMessage() const
 {
     readPipe();
 
+    if ( m_errorMsg.empty() && m_exitCode != 0 )
+        m_errorMsg = "Untwine exited with code: " + std::to_string( m_exitCode );
+
     return m_errorMsg;
 }
 

--- a/api/QgisUntwine.hpp
+++ b/api/QgisUntwine.hpp
@@ -39,9 +39,11 @@ private:
 #ifndef _WIN32
     pid_t m_pid;
     int m_progressFd;
+    int m_exitCode;
 #else
     HANDLE m_pid;
     HANDLE m_progressFd;
+    DWORD m_exitCode;
 #endif
 
     bool start(Options& options);

--- a/api/QgisUntwine_unix.cpp
+++ b/api/QgisUntwine_unix.cpp
@@ -65,7 +65,7 @@ bool QgisUntwine::stop()
     if (!m_running)
         return false;
     ::kill(m_pid, SIGINT);
-    (void)waitpid(m_pid, nullptr, 0);
+    (void)waitpid(m_pid, &m_exitCode, 0);
     m_pid = 0;
     return true;
 }
@@ -78,7 +78,7 @@ void QgisUntwine::childStopped()
 
 bool QgisUntwine::running()
 {
-    if (m_running && (::waitpid(m_pid, nullptr, WNOHANG) != 0))
+    if (m_running && (::waitpid(m_pid, &m_exitCode, WNOHANG) != 0))
         childStopped();
     return m_running;
 }

--- a/api/QgisUntwine_win.cpp
+++ b/api/QgisUntwine_win.cpp
@@ -76,6 +76,7 @@ bool QgisUntwine::stop()
 void QgisUntwine::childStopped()
 {
     m_running = false;
+    GetExitCodeProcess(m_pid, &m_exitCode);
     CloseHandle(m_progressFd);
     CloseHandle(m_pid);
 }


### PR DESCRIPTION
In the -hopefully rare- case that untwine crashes there is no error show to the user in QGIS (see https://github.com/qgis/QGIS/issues/48307)

I wonder if this is a good approach to tackle this, by propagating the exit code from the untwine process to the `QgisUntwine::errorMessage` ...