### PR TITLE
Pass `nosrs` to las reader to prevent crashing on some incorrectly set global encoding WKT flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@ Options
 - a_srs
 
   Assign an output SRS. Example `--a_srs EPSG:2056`
-  
+
+- no_srs
+
+  Don't read the SLR VLRs. This is only applicable to las files. [Default: false]
+
 - dims
 
   List of dimensions to load. X, Y and Z are always loaded. Limiting the dimensions can

--- a/epf/Epf.cpp
+++ b/epf/Epf.cpp
@@ -286,7 +286,8 @@ void Epf::createFileInfos(const StringList& input, std::vector<FileInfo>& fileIn
 
         pdal::Options opts;
         opts.add("filename", filename);
-        opts.add("nosrs", m_b.opts.no_srs);
+        if (driver == "readers.las")
+            opts.add("nosrs", m_b.opts.no_srs);
         s->setOptions(opts);
 
         FileInfo fi;

--- a/epf/Epf.cpp
+++ b/epf/Epf.cpp
@@ -292,6 +292,7 @@ void Epf::createFileInfos(const StringList& input, std::vector<FileInfo>& fileIn
         FileInfo fi;
         fi.filename = filename;
         fi.driver = driver;
+        fi.no_srs = m_b.opts.no_srs;
         if (driver == "readers.las")
         {
             const std::vector<FileInfo>& infos = processLas(*dynamic_cast<LasReader *>(s), fi);

--- a/epf/Epf.cpp
+++ b/epf/Epf.cpp
@@ -286,6 +286,7 @@ void Epf::createFileInfos(const StringList& input, std::vector<FileInfo>& fileIn
 
         pdal::Options opts;
         opts.add("filename", filename);
+        opts.add("nosrs", m_b.opts.no_srs);
         s->setOptions(opts);
 
         FileInfo fi;

--- a/epf/EpfTypes.hpp
+++ b/epf/EpfTypes.hpp
@@ -48,6 +48,7 @@ struct FileInfo
 
     std::string filename;
     std::string driver;
+    bool no_srs = false;
     DimInfoList dimInfo;
     uint64_t numPoints;
     uint64_t start;

--- a/epf/EpfTypes.hpp
+++ b/epf/EpfTypes.hpp
@@ -48,7 +48,7 @@ struct FileInfo
 
     std::string filename;
     std::string driver;
-    bool no_srs = false;
+    bool no_srs;
     DimInfoList dimInfo;
     uint64_t numPoints;
     uint64_t start;

--- a/epf/FileProcessor.cpp
+++ b/epf/FileProcessor.cpp
@@ -133,6 +133,7 @@ void FileProcessor::run()
     pdal::Options opts;
     opts.add("filename", m_fi.filename);
     opts.add("count", m_fi.numPoints);
+    opts.add("nosrs", m_fi.no_srs);
 #ifdef PDAL_LAS_START
     if (m_fi.driver == "readers.las")
         opts.add("start", m_fi.start);

--- a/epf/FileProcessor.cpp
+++ b/epf/FileProcessor.cpp
@@ -133,7 +133,8 @@ void FileProcessor::run()
     pdal::Options opts;
     opts.add("filename", m_fi.filename);
     opts.add("count", m_fi.numPoints);
-    opts.add("nosrs", m_fi.no_srs);
+    if (m_fi.driver == "readers.las")
+        opts.add("nosrs", m_fi.no_srs);
 #ifdef PDAL_LAS_START
     if (m_fi.driver == "readers.las")
         opts.add("start", m_fi.start);

--- a/untwine/Common.hpp
+++ b/untwine/Common.hpp
@@ -49,6 +49,7 @@ struct Options
     StringList dimNames;
     bool stats;
     std::string a_srs;
+    bool no_srs;
     bool metadata;
     bool dummy;
 };

--- a/untwine/Untwine.cpp
+++ b/untwine/Untwine.cpp
@@ -49,6 +49,8 @@ void addArgs(pdal::ProgramArgs& programArgs, Options& options, pdal::Arg * &temp
         options.a_srs, "");
     programArgs.add("metadata", "Write PDAL metadata to VLR output",
         options.metadata, false);
+    programArgs.add("no_srs", "PDAL readers.las.nosrs passthrough.",
+        options.no_srs, false);
 }
 
 bool handleOptions(pdal::StringList& arglist, Options& options)


### PR DESCRIPTION
We encountered this issue for datasets that are like: https://github.com/qgis/QGIS/issues/51862
The option to disable parsing SRS is in: https://github.com/PDAL/PDAL/pull/3818

In this PR we allow untwine to pass this option to las readers when specified and applicable only to las readers.