### PR TITLE
default to use_eb_vlr=true for readers.las

### DIFF
--- a/epf/Epf.cpp
+++ b/epf/Epf.cpp
@@ -290,7 +290,10 @@ void Epf::createFileInfos(const StringList& input, std::vector<FileInfo>& fileIn
         pdal::Options opts;
         opts.add("filename", filename);
         if (driver == "readers.las")
+        {
             opts.add("nosrs", m_b.opts.no_srs);
+            opts.add("use_eb_vlr", "true");
+        }
         s->setOptions(opts);
 
         FileInfo fi;

--- a/epf/FileProcessor.cpp
+++ b/epf/FileProcessor.cpp
@@ -136,6 +136,7 @@ void FileProcessor::run()
     if (m_fi.driver == "readers.las")
     {
         opts.add("nosrs", m_fi.no_srs);
+        opts.add("use_eb_vlr", "true");
 #ifdef PDAL_LAS_START
         opts.add("start", m_fi.start);
 #endif


### PR DESCRIPTION
This will fix issues like https://github.com/qgis/QGIS/issues/56945

Any valid reason to create an option for that and not to have it as true by default?