### PR TITLE
qgisuntwine_win: Fix startupInfo parameter

### DIFF
--- a/api/QgisUntwine_win.cpp
+++ b/api/QgisUntwine_win.cpp
@@ -28,7 +28,7 @@ bool QgisUntwine::start(Options& options)
         cmdline += "--" + op.first + " \"" + op.second + "\" ";
 
     PROCESS_INFORMATION processInfo;
-    STARTUPINFO startupInfo;
+    STARTUPINFOA startupInfo;
 
     ZeroMemory(&processInfo, sizeof(PROCESS_INFORMATION));
     ZeroMemory(&startupInfo, sizeof(STARTUPINFO));


### PR DESCRIPTION
This fixes compilation with vcpkg.

See: https://github.com/qgis/QGIS/commit/8a94723dc12b41babed8ec2c1dff4418f9424bf8