### PR TITLE
Read crs from input files

### DIFF
--- a/prep/FilePrep.cpp
+++ b/prep/FilePrep.cpp
@@ -403,6 +403,8 @@ std::vector<FileInfo> FilePrep::processLas(pdal::LasReader& r, FileInfo fi)
     fi.xform.offset.y = h.offsetY();
     fi.xform.offset.z = h.offsetZ();
 
+    fi.srs = h.srs();
+
     if (m_b.preserveHeaderFields())
     {
         m_b.globalEncoding = h.globalEncoding();
@@ -460,6 +462,7 @@ FileInfo FilePrep::processGeneric(pdal::Stage& s, FileInfo fi)
 
     fi.bounds = qi.m_bounds;
     fi.numPoints = qi.m_pointCount;
+    fi.srs = qi.m_srs;
 
     for (const std::string& name : qi.m_dimNames)
         fi.dimInfo.push_back(FileDimInfo(name));


### PR DESCRIPTION
This fixes a long standing issue, untwine is ignoring the input files' crs.
There have been related open issues in QGIS (eg https://github.com/qgis/QGIS/issues/59662), however the issue has gone some times undetected due to QGIS reading the crs from the .las/.laz file when this is loaded instead of reading it from the copc.

To replicate:
```bash
$ pdal info --metadata test/data/autzen_trim.laz
# input file has crs
$ untwine -i test/data/autzen_trim.laz -o test/data/autzen_trim.copc.laz -s
$ pdal info --metadata test/data/autzen_trim.copc.laz
# output file has no crs :(
```