### PR TITLE
Fix progress descriptor for linux

### DIFF
--- a/untwine/generic/progress.hpp
+++ b/untwine/generic/progress.hpp
@@ -17,7 +17,7 @@ inline bool writeMessage(int fd, int32_t msgId, uint32_t percent, const std::str
     err |= (::write(fd, message.data(), ssize) == -1);
     if (err)
         ::close(fd);
-    return err;
+    return !err;
 }
 
 inline bool writeErrorMessage(int fd, int32_t msgId, const std::string& message)
@@ -29,7 +29,7 @@ inline bool writeErrorMessage(int fd, int32_t msgId, const std::string& message)
     err |= (::write(fd, message.data(), ssize) == -1);
     if (err)
         ::close(fd);
-    return err;
+    return !err;
 }
 
 } // namespace os


### PR DESCRIPTION
This has been broken for some time and only the first message would be written to the descriptor. 
`writeMessage()` would then return `false` on no error and the caller would set `m_fd` to `-1` to stop the messages.

In windows those methods just return `true` so there's no problem.